### PR TITLE
Add return icons and dark theme

### DIFF
--- a/src/BillsList.js
+++ b/src/BillsList.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { fetchBills, markBillPaid } from './api.js';
 
 export default function BillsList({ status }) {
@@ -35,6 +36,11 @@ export default function BillsList({ status }) {
   return e(
     'div',
     null,
+    e(
+      Link,
+      { to: '/', className: 'icon', style: { marginBottom: '1rem' } },
+      '↩'
+    ),
     e('h2', null, status === 'paid' ? 'Paid Bills' : 'Unpaid Bills'),
     e(
       'div',

--- a/src/CreateBill.js
+++ b/src/CreateBill.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { createBill } from './api.js';
 
 const billTypes = [
@@ -54,6 +54,11 @@ export default function CreateBill() {
   return e(
     'div',
     null,
+    e(
+      Link,
+      { to: '/', className: 'icon', style: { marginBottom: '1rem' } },
+      '↩'
+    ),
     e('h2', null, 'Create Bill'),
     error && e('p', { style: { color: 'red' } }, error),
     e(

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,11 +1,21 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 export default function Home() {
   const e = React.createElement;
+  const navigate = useNavigate();
   return e(
     'div',
     null,
+    e(
+      'span',
+      {
+        className: 'icon',
+        onClick: () => navigate(-1),
+        style: { marginBottom: '1rem', cursor: 'pointer' }
+      },
+      '↩'
+    ),
     e('h1', null, 'Bills Reminder'),
     e(
       'nav',

--- a/styles.css
+++ b/styles.css
@@ -2,14 +2,16 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
-  background-color: #f4f6f8;
+  background-color: #000;
+  color: #fff;
 }
 
 .container {
   max-width: 800px;
   margin: 0 auto;
   padding: 20px;
-  background: #fff;
+  background: #000;
+  color: #fff;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
@@ -26,6 +28,14 @@ nav a {
 
 nav a:hover {
   text-decoration: underline;
+}
+
+.icon {
+  display: inline-block;
+  padding: 0.25rem;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  text-decoration: none;
 }
 
 form {


### PR DESCRIPTION
## Summary
- switch to black page background and add reusable rounded icon style
- add back arrow icons on pages to return home
- include back arrow on homepage for navigating to previous view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898b11b9304832e8e34c806808e8787