### PR TITLE
Add global return button for non-home pages

### DIFF
--- a/src/BillsList.js
+++ b/src/BillsList.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { fetchBills, markBillPaid } from './api.js';
 
 export default function BillsList({ status }) {
@@ -36,11 +35,6 @@ export default function BillsList({ status }) {
   return e(
     'div',
     null,
-    e(
-      Link,
-      { to: '/', className: 'icon', style: { marginBottom: '1rem' } },
-      '↩'
-    ),
     e('h2', null, status === 'paid' ? 'Paid Bills' : 'Unpaid Bills'),
     e(
       'div',

--- a/src/CreateBill.js
+++ b/src/CreateBill.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { createBill } from './api.js';
 
 const billTypes = [
@@ -54,11 +54,6 @@ export default function CreateBill() {
   return e(
     'div',
     null,
-    e(
-      Link,
-      { to: '/', className: 'icon', style: { marginBottom: '1rem' } },
-      '↩'
-    ),
     e('h2', null, 'Create Bill'),
     error && e('p', { style: { color: 'red' } }, error),
     e(

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,21 +1,11 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 export default function Home() {
   const e = React.createElement;
-  const navigate = useNavigate();
   return e(
     'div',
     null,
-    e(
-      'span',
-      {
-        className: 'icon',
-        onClick: () => navigate(-1),
-        style: { marginBottom: '1rem', cursor: 'pointer' }
-      },
-      '↩'
-    ),
     e('h1', null, 'Bills Reminder'),
     e(
       'nav',

--- a/src/main.js
+++ b/src/main.js
@@ -1,29 +1,42 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 
 import Home from './Home.js';
 import CreateBill from './CreateBill.js';
 import BillsList from './BillsList.js';
 
-function App() {
+function Layout() {
   const e = React.createElement;
+  const location = useLocation();
+  const navigate = useNavigate();
   return e(
-    BrowserRouter,
-    null,
-    e(
-      'div',
-      { className: 'container' },
+    'div',
+    { className: 'container' },
+    location.pathname !== '/' &&
       e(
-        Routes,
-        null,
-        e(Route, { path: '/', element: e(Home) }),
-        e(Route, { path: '/create', element: e(CreateBill) }),
-        e(Route, { path: '/paid', element: e(BillsList, { status: 'paid' }) }),
-        e(Route, { path: '/unpaid', element: e(BillsList, { status: 'unpaid' }) })
-      )
+        'span',
+        {
+          className: 'icon',
+          onClick: () => navigate(-1),
+          style: { marginBottom: '1rem', cursor: 'pointer' }
+        },
+        '↩'
+      ),
+    e(
+      Routes,
+      null,
+      e(Route, { path: '/', element: e(Home) }),
+      e(Route, { path: '/create', element: e(CreateBill) }),
+      e(Route, { path: '/paid', element: e(BillsList, { status: 'paid' }) }),
+      e(Route, { path: '/unpaid', element: e(BillsList, { status: 'unpaid' }) })
     )
   );
+}
+
+function App() {
+  const e = React.createElement;
+  return e(BrowserRouter, null, e(Layout));
 }
 
 createRoot(document.getElementById('root')).render(React.createElement(App));


### PR DESCRIPTION
## Summary
- Show return button on all pages except the homepage
- Remove duplicate per-page return buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b2d23cbc832e9b25a1406a5c4d15