### PR TITLE
Add ability to delete bills

### DIFF
--- a/src/BillsList.js
+++ b/src/BillsList.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { fetchBills, markBillPaid } from './api.js';
+import { fetchBills, markBillPaid, deleteBill } from './api.js';
 
 export default function BillsList({ status }) {
   const now = new Date();
@@ -25,6 +25,15 @@ export default function BillsList({ status }) {
   const handlePaid = async (id) => {
     try {
       await markBillPaid(id);
+      load();
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    try {
+      await deleteBill(id);
       load();
     } catch (err) {
       alert(err.message);
@@ -76,7 +85,7 @@ export default function BillsList({ status }) {
           e('th', null, 'Due Date'),
           e('th', null, 'Email'),
           e('th', null, 'Type'),
-          status === 'unpaid' && e('th', null, 'Actions')
+          e('th', null, 'Actions')
         )
       ),
       e(
@@ -90,16 +99,24 @@ export default function BillsList({ status }) {
             e('td', null, b.dueDate),
             e('td', null, b.email),
             e('td', null, b.type),
-            status === 'unpaid' &&
-              e(
-                'td',
-                { className: 'actions' },
+            e(
+              'td',
+              { className: 'actions' },
+              status === 'unpaid' &&
                 e(
                   'button',
                   { onClick: () => handlePaid(b.id) },
                   'Mark Paid'
-                )
+                ),
+              e(
+                'button',
+                {
+                  onClick: () => handleDelete(b.id),
+                  style: { marginLeft: status === 'unpaid' ? '0.5rem' : 0 }
+                },
+                'Delete'
               )
+            )
           )
         )
       )

--- a/src/api.js
+++ b/src/api.js
@@ -22,3 +22,8 @@ export async function markBillPaid(id) {
   const res = await fetch(`${API_BASE}/bills/${id}/paid`, { method: 'POST' });
   if (!res.ok) throw new Error('Failed to mark bill as paid');
 }
+
+export async function deleteBill(id) {
+  const res = await fetch(`${API_BASE}/bills/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error('Failed to delete bill');
+}


### PR DESCRIPTION
## Summary
- allow removing a bill by sending DELETE /{id}
- show Delete button for each bill in the list
- use `/bills/{id}` as the deletion endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898bcc5283c832e957f6cd9ebcdcb40